### PR TITLE
Add docker stack for developement only.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+DISCORD_CLIENT_ID="your_client_id_here"
+DISCORD_CLIENT_SECRET="your_client_secret_here"
+DISCORD_GUILD_ID="your_guild_id_here"
+ADMIN_ROLE_ID="your_admin_role_id_here"
+LEADER_ROLE_ID="your_leader_role_id_here"
+DISCORD_NEWS_WEBHOOK="your_webhook_url_here"
+NEXT_PUBLIC_SUPABASE_URL="your_supabase_url_here"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your_supabase_anon_key_here"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,109 @@
+# Colors
+CYAN := \033[36m
+GREEN := \033[32m
+YELLOW := \033[33m
+RESET := \033[0m
+
+# Docker commands
+DOCKER_RUN := docker run --rm -v $(shell pwd):/app -u $(shell id -u):$(shell id -g) -w /app
+DOCKER_NODE := $(DOCKER_RUN) node:22-alpine
+DOCKER_COMPOSE := docker compose -f docker/docker-compose.yml
+
+# Check if node_modules exists
+NODE_MODULES_EXISTS := $(shell test -d node_modules && echo 1 || echo 0)
+
+# Check if .env file exists
+ENV_FILE_EXISTS := $(shell test -f .env.local -o -f .env && echo 1 || echo 0)
+
+# Function to ensure node_modules exists
+define ensure_node_modules
+	@if [ ! -d "node_modules" ]; then \
+		echo "$(YELLOW)Node modules not found. Installing dependencies...$(RESET)"; \
+		$(DOCKER_NODE) npm ci --progress=true; \
+		echo "$(GREEN)Dependencies installed successfully.$(RESET)"; \
+	fi
+endef
+
+# Function to ensure .env file exists
+define ensure_env_file
+	@if [ "$(ENV_FILE_EXISTS)" = "0" ]; then \
+		echo "$(YELLOW)No .env file found. You need to create one for the application to work properly.$(RESET)"; \
+		echo "$(YELLOW)You can create it by copying the .env.example file:$(RESET)"; \
+		echo "$(CYAN)cp .env.example .env.local$(RESET)"; \
+		echo "$(YELLOW)Then edit it to set your environment variables.$(RESET)"; \
+		read -p "Do you want to create .env.local from .env.example now? (y/n) " answer; \
+		if [ "$$answer" = "y" ]; then \
+			cp .env.example .env.local; \
+			echo "$(GREEN).env.local created from .env.example. Please edit it with your configuration.$(RESET)"; \
+		else \
+			echo "$(YELLOW)Please create a .env file before running the application.$(RESET)"; \
+			exit 1; \
+		fi; \
+	fi
+endef
+
+install-node-modules:
+	@$(ensure_node_modules)
+
+# Run development server
+.PHONY: start-dev dev
+start-dev dev:
+	@echo "$(CYAN)Starting development server...$(RESET)"
+	$(call ensure_node_modules)
+	$(call ensure_env_file)
+	@UID=$(shell id -u) GID=$(shell id -g) COMPOSE_BAKE=true $(DOCKER_COMPOSE) build --no-cache
+	@UID=$(shell id -u) GID=$(shell id -g) COMPOSE_BAKE=true $(DOCKER_COMPOSE) up
+
+# Build the application
+.PHONY: build
+build:
+	@echo "$(CYAN)Building the application...$(RESET)"
+	$(call ensure_node_modules)
+	$(call ensure_env_file)
+	$(DOCKER_NODE) npm run build
+
+# Clean build artifacts
+.PHONY: clean
+clean:
+	@echo "$(CYAN)Cleaning build artifacts...$(RESET)"
+	$(call ensure_node_modules)
+	$(DOCKER_NODE) npm run clean
+
+# Add a dependency
+.PHONY: add-dependency
+add-dependency:
+	@echo "$(CYAN)Adding dependency: $(filter-out $@,$(MAKECMDGOALS))$(RESET)"
+	$(call ensure_node_modules)
+	$(DOCKER_NODE) npm install $(filter-out $@,$(MAKECMDGOALS)) --progress=true
+	@echo "$(GREEN)✅ Dependencies added successfully!$(RESET)"
+	@exit 0
+
+# Add a dev dependency
+.PHONY: add-dev-dependency
+add-dev-dependency:
+	@echo "$(CYAN)Adding dev dependency: $(filter-out $@,$(MAKECMDGOALS))$(RESET)"
+	$(call ensure_node_modules)
+	$(DOCKER_NODE) npm install --save-dev $(filter-out $@,$(MAKECMDGOALS)) --progress=true
+	@echo "$(GREEN)✅ Dev dependencies added successfully!$(RESET)"
+	@exit 0
+
+# Remove a dependency (works for both regular and dev dependencies)
+.PHONY: rm-dependency
+rm-dependency:
+	@echo "$(CYAN)Removing dependency: $(filter-out $@,$(MAKECMDGOALS))$(RESET)"
+	$(call ensure_node_modules)
+	$(DOCKER_NODE) npm uninstall $(filter-out $@,$(MAKECMDGOALS)) --progress=true
+	@echo "$(GREEN)✅ Dependencies removed successfully!$(RESET)"
+	@exit 0
+
+# Run linter
+.PHONY: lint
+lint:
+	@echo "$(CYAN)Running linter...$(RESET)"
+	$(call ensure_node_modules)
+	$(DOCKER_NODE) npm run lint
+
+# Special rule to handle arguments passed to make command
+# This is needed for the filter-out approach to work correctly
+%:
+	@:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# DyingStar Website
+
+## Local Development
+
+### Requirements
+- [Docker](https://www.docker.com/get-started)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Make](https://www.gnu.org/software/make/) to use the provided Makefile (optional but recommended)
+
+### Setup
+1. Copy `.env.example` to `.env.local` and fill in the required environment variables
+2. Run `make dev` to start the development server. This will install dependencies and start the server.
+3. Open your browser and navigate to `http://localhost:3000` to see the website.
+4. To stop the development server, stop the Docker container with `Ctrl+C` in the terminal where `make dev` was run.
+
+### Notes
+- The development server supports hot-reloading, so any changes you make to the code will automatically be reflected in the browser.
+- If you need to install new dependencies, you can do so by running `make add-dependency <package-name>` or `make add-dev-dependency <package-name>` for dev dependencies.

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,35 @@
+# Dependencies
+node_modules
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+
+# Next.js build output
+.next
+out
+
+# Testing
+coverage
+
+# Misc
+.DS_Store
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Git
+.git
+.gitignore
+
+# Docker
+docker
+Dockerfile
+.dockerignore
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,15 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Command to run the development server
+CMD ["npm", "run", "dev"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - ..:/app
+    environment:
+      - NODE_ENV=development
+    env_file:
+      - ../.env.local
+    command: npm run dev
+    user: "${UID:-1000}:${GID:-1000}"
+    tty: true


### PR DESCRIPTION
This is a PR for the issue #11 . 

At this moment, I only add a full local docker development  stack, with Makefile command, hot reloading, and a small README.md. 

I can add the dockerfile and CI for production, but I don't have any info for the Docker Registry or build guideline.